### PR TITLE
support unregister/replace when pulling metrics

### DIFF
--- a/registry_test.go
+++ b/registry_test.go
@@ -10,17 +10,27 @@ import (
 )
 
 func TestRegistry_PullFrom(t *testing.T) {
-	r := &lft.Registry{}
-	b := metrics.NewRegistry()
+	r1 := &lft.Registry{}
+	r2 := metrics.NewRegistry()
 
-	metrics.GetOrRegisterCounter("a", r)
-	metrics.GetOrRegisterCounter("b", b)
+	a := metrics.GetOrRegisterCounter("a", r1)
+	b := metrics.GetOrRegisterCounter("b", r2)
 
-	n := r.PullFrom(b)
-	assert.Equal(t, 1, n)
+	r1.PullFrom(r2)
+	assert.Equal(t, a, r1.Get("a"))
+	assert.Equal(t, b, r1.Get("b"))
 
-	assert.NotNil(t, r.Get("a"))
-	assert.NotNil(t, r.Get("b"))
+	r2.Unregister("b")
+
+	r1.PullFrom(r2)
+	assert.Equal(t, a, r1.Get("a"))
+	assert.Equal(t, nil, r1.Get("b"))
+
+	r2.Unregister("a")
+	a2 := metrics.GetOrRegisterCounter("a", r2)
+
+	r1.PullFrom(r2)
+	assert.Equal(t, a2, r1.Get("a"))
 }
 
 func TestRegistry_Register(t *testing.T) {


### PR DESCRIPTION
We primarily use `DefaultRegistry` from the go-lock_free_timer (`lft`) package. As we have cases where metrics are also added to `DefaultRegistry` from go-metrics (`metrics`), the `PullFrom` function is used to add metrics from `metrics.DefaultRegistry` to `lft.DefaultRegistry` so they can be exported. This does not work correctly when metrics are unregistered and/or replaced. For example, consider the following scenario:

```
m := metrics.GetOrRegisterCounter("service counter", metrics.DefaultRegistry)
// PullFrom will add m to lft.DefaultRegistry with the key "service counter"

metrics.DefaultRegistry.Unregister(m)
// m is no longer being used but remains in lft.DefaultRegistry

m2 := metrics.GetOrRegisterCounter("service counter", metrics.DefaultRegistry)
// PullFrom will ignore m2 as the key "service counter" already exists in lft.DefaultRegistry
```

Here, the exported value for the "service counter" metric will be taken from `m` even though it should be taken from `m2`.
