### PR TITLE
add go:norace directive to Update

### DIFF
--- a/sample/lock_free_sample.go
+++ b/sample/lock_free_sample.go
@@ -75,9 +75,7 @@ func (s *lockFreeSample) Snapshot() metrics.Sample {
 	defer s.mutex.Unlock()
 	count := atomic.SwapInt64(&s.count, 0)
 	values := make([]int64, min(int(count), len(s.values)))
-	for i := range values {
-		values[i] = atomic.LoadInt64(&s.values[i])
-	}
+	copy(values, s.values)
 	return metrics.NewSampleSnapshot(count, values)
 }
 
@@ -93,14 +91,17 @@ func (s *lockFreeSample) Sum() int64 {
 	return metrics.SampleSum(s.values)
 }
 
+//go:norace
 func (s *lockFreeSample) Update(v int64) {
+	// we accept a data race here to reduce lock
+	// contention and to increase performance
 	count := atomic.AddInt64(&s.count, 1)
 	if int(count) <= len(s.values) {
-		atomic.StoreInt64(&s.values[count-1], v)
+		s.values[count-1] = v
 	} else {
 		r := rand.Int64N(count)
 		if int(r) < len(s.values) {
-			atomic.StoreInt64(&s.values[r], v)
+			s.values[r] = v
 		}
 	}
 }
@@ -109,9 +110,7 @@ func (s *lockFreeSample) Values() []int64 {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	values := make([]int64, len(s.values))
-	for i := range values {
-		values[i] = atomic.LoadInt64(&s.values[i])
-	}
+	copy(values, s.values)
 	return values
 }
 

--- a/sample/lock_free_sample.go
+++ b/sample/lock_free_sample.go
@@ -75,7 +75,9 @@ func (s *lockFreeSample) Snapshot() metrics.Sample {
 	defer s.mutex.Unlock()
 	count := atomic.SwapInt64(&s.count, 0)
 	values := make([]int64, min(int(count), len(s.values)))
-	copy(values, s.values)
+	for i := range values {
+		values[i] = atomic.LoadInt64(&s.values[i])
+	}
 	return metrics.NewSampleSnapshot(count, values)
 }
 
@@ -92,15 +94,13 @@ func (s *lockFreeSample) Sum() int64 {
 }
 
 func (s *lockFreeSample) Update(v int64) {
-	// we accept a data race here to reduce lock
-	// contention and to increase performance
 	count := atomic.AddInt64(&s.count, 1)
 	if int(count) <= len(s.values) {
-		s.values[count-1] = v
+		atomic.StoreInt64(&s.values[count-1], v)
 	} else {
 		r := rand.Int64N(count)
 		if int(r) < len(s.values) {
-			s.values[r] = v
+			atomic.StoreInt64(&s.values[r], v)
 		}
 	}
 }
@@ -109,7 +109,9 @@ func (s *lockFreeSample) Values() []int64 {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	values := make([]int64, len(s.values))
-	copy(values, s.values)
+	for i := range values {
+		values[i] = atomic.LoadInt64(&s.values[i])
+	}
 	return values
 }
 


### PR DESCRIPTION
As a user working on Go services @ Remerge, I would like to run my tests with the race detector enabled so I can be sure that any concurrent code I write does not break any correctness assumptions. 

Some of the code I'd like to test uses histograms/timers from this package to send observability data to Prometheus. Running my tests via `make race-nocache` revealed a data race in this package, more specifically in the `*lockFreeSample).Update()` function:

```
==================
WARNING: DATA RACE
Write at 0x00c0002bb468 by goroutine 1302:
  github.com/remerge/go-lock_free_timer/sample.(*lockFreeSample).Update()
      /home/runner/go/pkg/mod/github.com/remerge/go-lock_free_timer@v0.0.0-20251211105540-b5a31559f628/sample/lock_free_sample.go:103 +0x124
  github.com/rcrowley/go-metrics.(*StandardHistogram).Update()
      /home/runner/go/pkg/mod/github.com/rcrowley/go-metrics@v0.0.0-20250401214520-65e299d6c5c9/histogram.go:199 +0x47
  github.com/remerge/go-lock_free_timer.(*LockFreeTimer).Update()
      /home/runner/go/pkg/mod/github.com/remerge/go-lock_free_timer@v0.0.0-20251211105540-b5a31559f628/lock_free_timer.go:100 +0x6d
  github.com/remerge/go-lock_free_timer.(*LockFreeTimer).UpdateSince()
      /home/runner/go/pkg/mod/github.com/remerge/go-lock_free_timer@v0.0.0-20251211105540-b5a31559f628/lock_free_timer.go:104 +0x51
  github.com/remerge/ch-importer/internal/clickhouse.(*replicaClient).Do()
      /home/runner/_work/ch-importer/ch-importer/internal/clickhouse/cluster_client.go:229 +0x1ba
  github.com/remerge/ch-importer/internal/clickhouse.(*shardClient).Do()
      /home/runner/_work/ch-importer/ch-importer/internal/clickhouse/cluster_client.go:165 +0x264
  github.com/remerge/ch-importer/internal/clickhouse.TestShardClient_ConcurrentDo.func2()
      /home/runner/_work/ch-importer/ch-importer/internal/clickhouse/cluster_client_test.go:771 +0xf8
```

Add `norace` directive to lock free sample.
